### PR TITLE
Add company contact details to footer

### DIFF
--- a/src/NianiakoudisSite/Shared/MainLayout.razor
+++ b/src/NianiakoudisSite/Shared/MainLayout.razor
@@ -11,6 +11,13 @@
     </main>
 
     <footer class="footer">
-        <span>© 2024 Νιανιακούδης</span>
+        <div class="footer-content">
+            <span>© 2024 Νιανιακούδης</span>
+            <div class="footer-contact">
+                <span>Telephone: <a href="tel:+302311234567">+30 231 123 4567</a></span>
+                <span>Email: <a href="mailto:info@nianiakoudis.gr">info@nianiakoudis.gr</a></span>
+                <span>LinkedIn: <a href="https://www.linkedin.com/company/nianiakoudis" target="_blank" rel="noopener noreferrer">linkedin.com/company/nianiakoudis</a></span>
+            </div>
+        </div>
     </footer>
 </div>

--- a/src/NianiakoudisSite/wwwroot/css/app.css
+++ b/src/NianiakoudisSite/wwwroot/css/app.css
@@ -115,6 +115,31 @@ body {
     border-top: 2px solid rgba(0, 0, 0, 0.05);
 }
 
+.footer-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.footer-contact {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem 1.5rem;
+    font-size: 0.95rem;
+}
+
+.footer-contact a {
+    color: inherit;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.footer-contact a:hover,
+.footer-contact a:focus-visible {
+    text-decoration: underline;
+}
+
 @media (max-width: 720px) {
     .top-bar {
         flex-direction: column;


### PR DESCRIPTION
### Motivation
- Provide clear company contact information (telephone, email, LinkedIn) in the site footer for visitors.
- Make contact items actionable using `tel:` and `mailto:` links and a safe external LinkedIn link.
- Keep the footer visually clean and responsive across viewports.

### Description
- Updated `src/NianiakoudisSite/Shared/MainLayout.razor` to add a structured footer block with telephone, email, and LinkedIn entries using `tel:`, `mailto:`, and an external `https://` link.
- Added `.footer-content` and `.footer-contact` styles to `src/NianiakoudisSite/wwwroot/css/app.css` to layout contact items, handle wrapping, and style links.
- Ensured external link uses `target="_blank" rel="noopener noreferrer"` for security and accessibility.

### Testing
- Attempted to run the site with `dotnet run --project src/NianiakoudisSite --urls http://0.0.0.0:5000` and it failed because `dotnet` is not available in the environment.
- No automated unit or integration tests were executed in this environment due to the missing runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed28158e0832ba2fe2704b92452bf)