### PR TITLE
Update Greek hero tagline wording

### DIFF
--- a/src/NianiakoudisSite/Resources/SharedResource.resx
+++ b/src/NianiakoudisSite/Resources/SharedResource.resx
@@ -272,7 +272,7 @@
     <value>ΛΟΓΙΣΤΙΚΟ &amp; ΦΟΡΟΤΕΧΝΙΚΟ ΓΡΑΦΕΙΟ</value>
   </data>
   <data name="Home.Hero.Line3Prefix" xml:space="preserve">
-    <value>Άνω των 30 ετών εμπειρίας</value>
+    <value>Άνω των 30 ετών εμπειρία</value>
   </data>
   <data name="Home.Hero.Line3Suffix" xml:space="preserve">
     <value>μαζί σας</value>


### PR DESCRIPTION
### Motivation
- Fix the Greek hero tagline phrasing so the rendered line reads `Άνω των 30 ετών εμπειρία μαζί σας` instead of `Άνω των 30 ετών εμπειρίας μαζί σας`.

### Description
- Update `src/NianiakoudisSite/Resources/SharedResource.resx` by replacing `Άνω των 30 ετών εμπειρίας` with `Άνω των 30 ετών εμπειρία`.

### Testing
- No automated tests were run for this text-only resource string change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed02615584832babeb4209137e08f2)